### PR TITLE
Fix book images

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,10 @@ gem 'puma'
 gem 'sass-rails',   '~> 4.0.3'
 gem 'uglifier', '~> 2.5.3'
 
+group :test, :development do
+  gem 'pry-byebug'
+end
+
 group :test do
   gem "minitest-spec-rails"
   gem "capybara-webkit"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,6 +42,7 @@ GEM
       multi_json
     arel (6.0.3)
     builder (3.2.2)
+    byebug (9.0.6)
     capybara (2.7.0)
       addressable
       mime-types (>= 1.16)
@@ -52,6 +53,7 @@ GEM
     capybara-webkit (1.10.1)
       capybara (>= 2.3.0, < 2.8.0)
       json
+    coderay (1.1.1)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     database_cleaner (1.5.1)
@@ -95,6 +97,7 @@ GEM
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
     metaclass (0.0.4)
+    method_source (0.8.2)
     mime-types (2.99.1)
     mini_portile2 (2.0.0)
     minitest (5.8.4)
@@ -136,6 +139,13 @@ GEM
       activesupport (>= 3.0, < 5.0)
     pg (0.18.4)
     possessive (1.0.1)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    pry-byebug (3.4.0)
+      byebug (~> 9.0)
+      pry (~> 0.10)
     puma (3.4.0)
     rack (1.6.4)
     rack-ssl-enforcer (0.2.9)
@@ -182,6 +192,7 @@ GEM
       sass (~> 3.2.2)
       sprockets (~> 2.8, < 3.0)
       sprockets-rails (~> 2.0)
+    slop (3.6.0)
     sprockets (2.12.4)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -228,6 +239,7 @@ DEPENDENCIES
   paper_trail (~> 3.0.5)
   pg
   possessive
+  pry-byebug
   puma
   rack-ssl-enforcer
   rails (= 4.2.6)
@@ -236,5 +248,8 @@ DEPENDENCIES
   uglifier (~> 2.5.3)
   webmock
 
+RUBY VERSION
+   ruby 2.3.0p0
+
 BUNDLED WITH
-   1.11.2
+   1.13.5

--- a/app/helpers/books_helper.rb
+++ b/app/helpers/books_helper.rb
@@ -4,7 +4,7 @@ module BooksHelper
     zoom = cover_sizes[size]
 
     if book.google_id
-      image_tag "http://bks0.books.google.co.uk/books?id=#{book.google_id}&printsec=frontcover&img=1&zoom=#{zoom}&edge=none&source=gbs_api", :alt => "#{book.title} by #{book.author}"
+      image_tag "http://books.google.co.uk/books?id=#{book.google_id}&printsec=frontcover&img=1&zoom=#{zoom}&edge=none&source=gbs_api", :alt => "#{book.title} by #{book.author}"
     else
       content_tag :div, :class => "placeholder_book" do
         concat(book.title)
@@ -16,7 +16,7 @@ module BooksHelper
   def cover_urls(book, size = "S")
     response = { }
 
-    response[:google] = "http://bks0.books.google.co.uk/books?id=#{book[:google_id]}&printsec=frontcover&img=1&zoom=#{cover_sizes[size]}&edge=none&source=gbs_api" if book[:google_id]
+    response[:google] = "http://books.google.co.uk/books?id=#{book[:google_id]}&printsec=frontcover&img=1&zoom=#{cover_sizes[size]}&edge=none&source=gbs_api" if book[:google_id]
     response[:openlibrary] = "http://covers.openlibrary.org/b/olid/#{book[:openlibrary_id]}-M.jpg" if book[:openlibrary_id]
 
     response

--- a/test/integration/book_actions_test.rb
+++ b/test/integration/book_actions_test.rb
@@ -16,7 +16,7 @@ class BookActionsTest < ActionDispatch::IntegrationTest
         visit "/books/#{@book.id}"
 
         within ".cover" do
-          assert page.has_selector?("img[src='http://bks0.books.google.co.uk/books?id=mock-google-id&printsec=frontcover&img=1&zoom=1&edge=none&source=gbs_api']")
+          assert page.has_selector?("img[src='http://books.google.co.uk/books?id=mock-google-id&printsec=frontcover&img=1&zoom=1&edge=none&source=gbs_api']")
         end
 
         within ".title" do


### PR DESCRIPTION
Book images from Google are currenly broken since the subdomain has changed. This commit fixes the subdomain so that the images show up again. It also adds the `pry-byebug` gem for development and testing.