### PR TITLE
Set title attribute for book images

### DIFF
--- a/app/helpers/books_helper.rb
+++ b/app/helpers/books_helper.rb
@@ -4,7 +4,7 @@ module BooksHelper
     zoom = cover_sizes[size]
 
     if book.google_id
-      image_tag "http://books.google.co.uk/books?id=#{book.google_id}&printsec=frontcover&img=1&zoom=#{zoom}&edge=none&source=gbs_api", :alt => "#{book.title} by #{book.author}"
+      image_tag "http://books.google.co.uk/books?id=#{book.google_id}&printsec=frontcover&img=1&zoom=#{zoom}&edge=none&source=gbs_api", :alt => "#{book.title} by #{book.author}", :title => "#{book.title} by #{book.author}"
     else
       content_tag :div, :class => "placeholder_book" do
         concat(book.title)


### PR DESCRIPTION
This commit sets the `title` attribute for book images to the same as the `alt` attribute. This enables users to hover over the book images to see the name and author of the book; useful for cases when the book images is too small to read.
