### PR TITLE
Export a CSV of books and their statuses

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -1,3 +1,5 @@
+require 'csv'
+
 class RootController < ApplicationController
 
   def start
@@ -6,6 +8,36 @@ class RootController < ApplicationController
     @recent_loans = Loan.recently_loaned.includes([:book, :copy]).limit(5)
 
     # start.html.erb
+  end
+
+  CSV_HEADINGS = %w(id title author isbn number_of_copies on_loan_copies).freeze
+  def library_csv
+    data = CSV.generate do |csv|
+      csv << CSV_HEADINGS
+      Book.all.each do |b|
+        book = []
+        book = [
+          b['id'],
+          b['title'],
+          b['author'],
+          b['isbn'],
+          b.copies.count,
+          number_of_copies_on_loan(b)
+        ]
+        csv << book
+      end
+    end
+    send_data data, filename: "library.csv"
+  end
+
+private
+  def number_of_copies_on_loan(b)
+    loan_count = 0
+    b.copies.each do |c|
+      loan_count += 1 if c.on_loan?
+    end
+
+    "#{loan_count}/#{b.copies.count}"
   end
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,8 @@ Books::Application.routes.draw do
   match "auth/:provider/callback" => "sessions#create", via: [:get, :post]
   get "auth/sign_out" => "sessions#sign_out", :as => :sign_out
 
+  get "library.csv", to: "root#library_csv"
+
   resources :sessions, :only => :new do
     get :failure, :collection => true
   end


### PR DESCRIPTION
- For now, this is a CSV of all the books in the library, the number of copies, and the number of copies out on loan. It generates on the fly on every request of /library.csv.
- An improvement could be the same or another CSV to display who is borrowing each copy.
- At some point I'll get around to adding tests, I need to get this feature out quickly though. Tested by deploying the branch to Heroku and it works.