### PR TITLE
Add shelves

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ end
 
 group :test do
   gem "minitest-spec-rails"
-  gem "capybara-webkit"
+  gem "capybara"
   gem "factory_girl_rails", '4.1.0'
   gem "database_cleaner"
   gem "webmock", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby "2.3.0"
+ruby "~> 2.3.0"
 
 gem 'rails', '4.2.6'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,9 +50,6 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    capybara-webkit (1.10.1)
-      capybara (>= 2.3.0, < 2.8.0)
-      json
     coderay (1.1.1)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
@@ -225,7 +222,7 @@ PLATFORMS
 
 DEPENDENCIES
   airbrake (~> 4.0.0)
-  capybara-webkit
+  capybara
   database_cleaner
   factory_girl_rails (= 4.1.0)
   formtastic
@@ -252,4 +249,4 @@ RUBY VERSION
    ruby 2.3.0p0
 
 BUNDLED WITH
-   1.13.5
+   1.14.6

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ The app is configured with a collection of environment variables:
 * `GITHUB_ORG` - organisation username to restrict access
 * `REQUEST_IP` - IP address to provide as the requester in calls to the Google Books API (required for Heroku)
 * `RAILS_SECRET_TOKEN`
+* `DB_USERNAME`
+* `DB_PASSWORD`
+* `DB_HOST`
+* `DB_PORT`
 
 If you're using Airbrake or Errbit, you can set the following environment variables:
 

--- a/app/assets/stylesheets/books.scss
+++ b/app/assets/stylesheets/books.scss
@@ -113,6 +113,11 @@ ul.copies {
     font-size: 1em;
 
     p, h2 { display: inline; margin: 0; padding: 0; font-size: 1em; }
+
+    .shelf {
+      font-weight: normal;
+      font-size: 80%;
+    }
     h2 { display: inline-block; font-weight: normal;  width: 2.5em; }
     .btn { font-size: 1rem; }
 
@@ -160,6 +165,32 @@ ul.copies {
     background: #ddd;
     border-left: 12px solid #d2381d;
   }
+
+  form.copy {
+    float: right;
+    ul, li {
+      display: inline-block;
+      background: transparent;
+      padding: 0;
+    }
+    li {
+      overflow: initial;
+    }
+
+    #copy_shelf_input {
+      label {
+        width: 6em;
+        text-align: right;
+        padding-right: .3em;
+      }
+      select {
+        width: 7em;
+      }
+    }
+    display: inline-block;
+    background: transparent;
+  }
+
 }
 
 table.history {

--- a/app/assets/stylesheets/copies.scss
+++ b/app/assets/stylesheets/copies.scss
@@ -1,11 +1,49 @@
-.new-copy {
+.new-copy, .edit-copy {
   .formtastic .actions {
     padding: 1em 0 0 0;
+  }
+
+  .formtastic {
+    display: block;
   }
 
   .formtastic .inline-errors {
     float: none;
     margin: 0;
+  }
+}
+
+.edit-copy .copy-display {
+  height: 200px;
+  line-height: 200px;
+  vertical-align: middle;
+
+  .cover {
+    display: inline-block;
+    line-height: normal;
+    vertical-align: middle;
+  }
+
+  dl.copy-number {
+    display: inline-block;
+    margin: 0 0 0 2em;
+    vertical-align: middle;
+    line-height: normal;
+
+    dt {
+      display: inline-block;
+      font-weight: normal;
+      line-height: normal;
+    vertical-align: middle;
+    }
+
+    dd {
+      display: inline-block;
+      font-weight: bold;
+      font-size: 300%;
+    line-height: normal;
+    vertical-align: middle;
+    }
   }
 }
 
@@ -41,6 +79,18 @@ fieldset.copy-number {
       padding: 0.35em;
       font-size: 1.2em;
     }
+  }
+}
+
+fieldset.shelf {
+  display: block;
+  margin: 1.5em 0 0 0;
+  padding: 1em;
+  background: #eee;
+  border-bottom: 1px solid #ccc;
+
+  li.input {
+    margin-bottom: 0;
   }
 }
 

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -7,6 +7,7 @@ class BooksController < ApplicationController
   has_scope :availability do |controller, scope, value|
     case value
     when "available" then scope.available
+    when /^shelf_[0-9]+$/ then scope.shelf(value.split('_')[1])
     when "on_loan" then scope.on_loan
     when "missing" then scope.missing
     else

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -27,8 +27,14 @@ class BooksController < ApplicationController
     @book.created_by = current_user
 
     if params[:intent] == 'isbn-lookup'
-      assign_metadata_to_book(@book)
-      render action: :new
+      begin
+        assign_metadata_to_book(@book)
+        render action: :new
+      rescue BookMetadataLookup::BookNotFound
+        flash.now[:alert] = "Couldn't find book with isbn #{@book.isbn}"
+        render action: :new
+      end
+
       return
     end
 

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -18,6 +18,7 @@ class Book < ActiveRecord::Base
   scope :available, -> { joins(:copies).where(copies: { on_loan: false }) }
   scope :on_loan, -> { joins(:copies).where(copies: { on_loan: true }) }
   scope :missing, -> { joins(:copies).where(copies: { missing: true }) }
+  scope :shelf, ->(shelf_id) { joins(:copies).where(copies: { on_loan: false, shelf_id: shelf_id }) }
 
   default_scope -> { order("title ASC") }
 

--- a/app/models/copy.rb
+++ b/app/models/copy.rb
@@ -2,6 +2,7 @@ class Copy < ActiveRecord::Base
   belongs_to :book
   has_many :loans, :dependent => :destroy
   has_many :users, :through => :loans
+  belongs_to :shelf
 
   validates :book_reference, :presence => true, :uniqueness => { :case_sensitive => false }
 
@@ -52,12 +53,15 @@ class Copy < ActiveRecord::Base
     loans.create(:user => user)
   end
 
-  def return(as_user=nil)
+  def return(as_user=nil, to_shelf=nil)
     raise NotOnLoan unless on_loan?
 
     loans.where(:state => 'on_loan').each do |loan|
-      loan.return(as_user)
+      loan.return(as_user, to_shelf)
     end
+
+    self.shelf = to_shelf
+    self.save!
   end
 
   def set_missing

--- a/app/models/loan.rb
+++ b/app/models/loan.rb
@@ -2,6 +2,7 @@ class Loan < ActiveRecord::Base
   belongs_to :copy
   belongs_to :user
   belongs_to :returned_by, class_name: 'User'
+  belongs_to :returned_to_shelf, class_name: 'Shelf'
 
   has_one :book, :through => :copy
 
@@ -18,12 +19,13 @@ class Loan < ActiveRecord::Base
 
   class NotOnLoan < Exception; end
 
-  def return(as_user=nil)
+  def return(as_user=nil, to_shelf=nil)
     raise NotOnLoan unless state == "on_loan"
 
     self.state = 'returned'
     self.return_date = Time.now
     self.returned_by = as_user
+    self.returned_to_shelf = to_shelf
     self.save
   end
 
@@ -37,5 +39,11 @@ class Loan < ActiveRecord::Base
 
   def returned_by_another_user?
     returned_by.present? && user != returned_by
+  end
+
+  def duration
+    if loan_date && return_date
+      return_date - loan_date
+    end
   end
 end

--- a/app/models/shelf.rb
+++ b/app/models/shelf.rb
@@ -1,0 +1,7 @@
+class Shelf < ActiveRecord::Base
+  has_many :books
+
+  def to_s
+    name
+  end
+end

--- a/app/views/books/_filters.html.erb
+++ b/app/views/books/_filters.html.erb
@@ -3,6 +3,9 @@
     <h3>availability</h3>
     <ul>
       <li><%= filter_link "available", :availability, "available" %></li>
+      <% Shelf.all.each do |shelf| %>
+        <li><%= filter_link "- #{shelf}", :availability, "shelf_#{shelf.id}" %></li>
+      <% end %>
       <li><%= filter_link "on loan", :availability, "on_loan" %></li>
       <li><%= filter_link "missing", :availability, "missing" %></li>
     </ul>

--- a/app/views/copies/_copy.html.erb
+++ b/app/views/copies/_copy.html.erb
@@ -7,7 +7,16 @@
   <% if copy.on_loan? %>
     <p>
       On loan to <%= user_or_second_person copy.current_user, current_user %>
-      <%= link_to "Return", return_copy_path(copy), :class => 'btn', :method => :post %>
+
+      <%= semantic_form_for [:return, copy], method: :post do |f| %>
+        <ul>
+          <%= f.input :shelf,  :as => :select,      :collection => Shelf.all, include_blank: "unknown", label: "Return to" %>
+
+          <li><%= f.submit "Return" %></li>
+        </ul>
+
+      <% end %>
+
       <span class="since">since <%= copy.current_loan.loan_date.strftime("%b %d, %Y") %></span>
     </p>
   <% elsif copy.missing? %>
@@ -17,6 +26,13 @@
   <% elsif copy.available? %>
     <p>
       Available to borrow
+      <span class='shelf'>
+      <% if copy.shelf.present? %>
+        (<%= copy.shelf.to_s %> - <%= link_to "edit", edit_copy_path(copy) %>)
+      <% else %>
+        (shelf unknown - <%= link_to "set", edit_copy_path(copy) %>)
+      <% end %>
+      </span>
       <%= link_to "Borrow", borrow_copy_path(copy), :class => 'btn', :method => :post %>
     </p>
   <% end %>

--- a/app/views/copies/edit.html.erb
+++ b/app/views/copies/edit.html.erb
@@ -1,0 +1,27 @@
+<section class="resource wrap edit-copy">
+  <h1><%= @book.title %></h1>
+
+  <div class="copy-display">
+    <div class="cover"><%= book_cover_tag @book, :size => "S" %></div>
+
+    <dl class='copy-number'>
+      <dt>Copy number</dt>
+      <dd><%= @copy.book_reference %></dd>
+    </dl>
+  </div>
+
+  <%= semantic_form_for [@copy] do |f| %>
+    <h3>Which shelf is this book on?</h3>
+
+    <fieldset class="shelf">
+      <label>
+        <%= f.input :shelf,  :as => :select,      :collection => Shelf.all, include_blank: "unknown" %>
+      </label>
+    </fieldset>
+
+    <%= f.actions do %>
+      <%= f.submit "Set shelf" %>
+    <% end %>
+  <% end %>
+</section>
+

--- a/app/views/copies/new.html.erb
+++ b/app/views/copies/new.html.erb
@@ -22,6 +22,12 @@
       </label>
     </fieldset>
 
+    <fieldset class="shelf">
+      <label for="shelf">
+        <%= f.input :shelf,  :as => :select,      :collection => Shelf.all, include_blank: "unknown" %>
+      </label>
+    </fieldset>
+
     <%= f.actions do %>
       <%= f.submit "Add this copy" %>
     <% end %>

--- a/app/views/copies/show.html.erb
+++ b/app/views/copies/show.html.erb
@@ -17,9 +17,21 @@
   <% if @previous_loans.any? %>
     <h3>Loan history</h3>
     <table class="history">
+      <thead>
+        <tr>
+        <th>From</th>
+        <th>Until</th>
+        <th>Duration</th>
+        <th>Returned to</th>
+        <th>by</th>
+      </thead>
+
       <% @previous_loans.each do |loan| %>
       <tr>
-        <td><%= loan.loan_date.strftime("%e %B %Y") if loan.loan_date %> - <%= loan.return_date.strftime("%e %B %Y") if loan.return_date %></td>
+        <td><%= loan.loan_date.strftime("%e %B %Y") if loan.loan_date %></td>
+        <td><%= loan.return_date.strftime("%e %B %Y") if loan.return_date %></td>
+        <td><%= distance_of_time_in_words(loan.duration) if loan.duration %></td>
+        <td><%= loan.returned_to_shelf if loan.returned_to_shelf %></td>
         <td>
           <%= link_to loan.user.name, user_path(loan.user) %>
           <% if loan.returned_by_another_user? %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -18,14 +18,16 @@ development:
   database: books_development
   min_messages: warning
   pool: 5
-  username: books
-  password:
+  username: <%= ENV.fetch('DB_USERNAME', 'books') %>
+  password: <%= ENV.fetch('DB_PASSWORD', '') %>
 
   # Connect on a TCP socket. Omitted by default since the client uses a
   # domain socket that doesn't need configuration. Windows does not have
   # domain sockets, so uncomment these lines.
-  #host: localhost
-  #port: 5432
+  <% if ENV.has_key?('DB_HOST') %>
+  host: <%= ENV.fetch('DB_HOST', '') %>
+  port: <%= ENV.fetch('DB_PORT', '') %>
+  <% end %>
 
   # Schema search path. The server defaults to $user,public
   #schema_search_path: myapp,sharedapp,public
@@ -45,13 +47,21 @@ test:
   database: books_test
   min_messages: warning
   pool: 5
-  username: books
-  password:
+  username: <%= ENV.fetch('DB_USERNAME', 'books') %>
+  password: <%= ENV.fetch('DB_PASSWORD', '') %>
+  <% if ENV.has_key?('DB_HOST') %>
+  host: <%= ENV.fetch('DB_HOST', '') %>
+  port: <%= ENV.fetch('DB_PORT', '') %>
+  <% end %>
 
 production:
   adapter: postgresql
   encoding: unicode
   database: books_production
   pool: 5
-  username: books
-  password:
+  username: <%= ENV.fetch('DB_USERNAME', 'books') %>
+  password: <%= ENV.fetch('DB_PASSWORD', '') %>
+  <% if ENV.has_key?('DB_HOST') %>
+  host: <%= ENV.fetch('DB_HOST', '') %>
+  port: <%= ENV.fetch('DB_PORT', '') %>
+  <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,8 +29,10 @@ Books::Application.routes.draw do
       get :history
     end
 
-    resources :copies, :only => [:new, :create]
+    resources :copies
   end
+
+  resources :copies, :only => [:edit, :update]
 
   resources :user, :only => :show
 

--- a/db/migrate/20170408104943_add_shelves.rb
+++ b/db/migrate/20170408104943_add_shelves.rb
@@ -1,0 +1,14 @@
+class AddShelves < ActiveRecord::Migration
+  def change
+    create_table :shelves do |t|
+      t.string :name
+      t.timestamps
+    end
+
+    add_column :copies, :shelf_id, :integer, default: nil
+    add_column :loans, :returned_to_shelf_id, :integer, default: nil
+
+    execute "insert into shelves (name, created_at, updated_at) select 'Third floor', now(), now()"
+    execute "insert into shelves (name, created_at, updated_at) select 'Sixth floor', now(), now()"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,48 +16,48 @@ ActiveRecord::Schema.define(version: 20141003152512) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "books", force: true do |t|
+  create_table "books", force: :cascade do |t|
     t.string   "title"
     t.string   "isbn"
     t.string   "author"
     t.string   "google_id"
-    t.datetime "created_at",     null: false
-    t.datetime "updated_at",     null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.integer  "created_by_id"
     t.string   "openlibrary_id"
   end
 
-  create_table "copies", force: true do |t|
+  create_table "copies", force: :cascade do |t|
     t.integer  "book_id"
     t.integer  "book_reference",                 null: false
     t.boolean  "on_loan",        default: false, null: false
-    t.datetime "created_at",                     null: false
-    t.datetime "updated_at",                     null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.boolean  "missing",        default: false
   end
 
-  create_table "loans", force: true do |t|
+  create_table "loans", force: :cascade do |t|
     t.integer  "user_id"
     t.integer  "copy_id"
     t.string   "state",          default: "on_loan"
     t.datetime "loan_date"
-    t.datetime "created_at",                         null: false
-    t.datetime "updated_at",                         null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.datetime "return_date"
     t.integer  "returned_by_id"
   end
 
-  create_table "users", force: true do |t|
+  create_table "users", force: :cascade do |t|
     t.string   "name"
-    t.datetime "created_at",   null: false
-    t.datetime "updated_at",   null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.string   "email"
     t.string   "provider"
     t.string   "provider_uid"
     t.string   "image_url"
   end
 
-  create_table "versions", force: true do |t|
+  create_table "versions", force: :cascade do |t|
     t.string   "item_type",      null: false
     t.integer  "item_id",        null: false
     t.string   "event",          null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141003152512) do
+ActiveRecord::Schema.define(version: 20170408104943) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,17 +34,25 @@ ActiveRecord::Schema.define(version: 20141003152512) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.boolean  "missing",        default: false
+    t.integer  "shelf_id"
   end
 
   create_table "loans", force: :cascade do |t|
     t.integer  "user_id"
     t.integer  "copy_id"
-    t.string   "state",          default: "on_loan"
+    t.string   "state",                default: "on_loan"
     t.datetime "loan_date"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "return_date"
     t.integer  "returned_by_id"
+    t.integer  "returned_to_shelf_id"
+  end
+
+  create_table "shelves", force: :cascade do |t|
+    t.string   "name"
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "users", force: :cascade do |t|

--- a/test/factories/shelf.rb
+++ b/test/factories/shelf.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :shelf
+end

--- a/test/models/copy_test.rb
+++ b/test/models/copy_test.rb
@@ -120,6 +120,18 @@ describe Copy do
     end
   end
 
+  context "shelves" do
+    should "be able to set the shelf" do
+      copy = FactoryGirl.create(:copy)
+      copy.update_attributes(shelf_id: 1)
+
+      copy.reload
+
+      assert_equal 1, copy.shelf_id
+    end
+  end
+
+
   context "recently added copies" do
     should "return newest copies first" do
       # delete first auto-generated copy of book

--- a/test/models/loan_test.rb
+++ b/test/models/loan_test.rb
@@ -73,6 +73,14 @@ describe Loan do
       @loan.reload
       assert_equal returning_user, @loan.returned_by
     end
+
+    should 'set the returning shelf when present' do
+      shelf = create(:shelf)
+      @loan.return(nil, shelf)
+
+      @loan.reload
+      assert_equal shelf, @loan.returned_to_shelf
+    end
   end
 
 end


### PR DESCRIPTION
I got fed up of not having records of which books are where, so I've added support for shelves.

Hope this is useful!

## What it does

A shelf can be set for a book when it's not out on loan.

When a book is returned from loan, the shelf is also specified.

A record of the shelf which the book is returned to is kept in the
`loans` table.

(See screenshots)

## Default data

Two shelves will be created by the default migration:

- 'Third floor'
- 'Sixth floor'

(I realise this might be annoying if people outside of GDS are using this app, happy to remove the default data from the migration if that would be preferred).

## Tweaks/cleanups

I also did a few tweaks/cleanups:

- relax ruby version constraint in Gemfile
- remove dependency on capybara-webkit
- allow DB config to be overridden by env vars

And one bugfix:

- if a book isn't found by ISBN search, show a nice error message instead of crashing

## Screenshots

### Option to set the shelf for an existing book

![screen shot 2017-04-08 at 14 24 31](https://cloud.githubusercontent.com/assets/61065/24829335/418d380a-1c67-11e7-8e58-b9ea57c8e364.png)

### Editing the shelf

![screen shot 2017-04-08 at 14 24 48](https://cloud.githubusercontent.com/assets/61065/24829334/418ae672-1c67-11e7-8ab2-642cba6c097a.png)

### Returning a book that's on loan

![screen shot 2017-04-08 at 14 25 03](https://cloud.githubusercontent.com/assets/61065/24829333/41889b9c-1c67-11e7-9304-059e2eae64d3.png)

### Viewing the loan history

![screen shot 2017-04-08 at 14 25 17](https://cloud.githubusercontent.com/assets/61065/24829332/4183caf4-1c67-11e7-8d03-e765ba2cef42.png)
