### PR TITLE
Change config/environments/test.rb settings

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,4 +39,10 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  config.after_initialize do
+    PaperTrail.enabled = false
+  end
+
+  config.minitest_spec_rails.mini_shoulda = true
 end


### PR DESCRIPTION
To allow `context` to be used in tests and disable PaperTrail in tests