### PR TITLE
Remove unnecessary gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,8 +13,6 @@ gem "formtastic"
 gem "possessive"
 gem 'has_scope'
 
-gem 'rack-ssl-enforcer'
-
 gem 'paper_trail', '~> 7.0.2'
 
 gem 'jquery-rails'
@@ -36,8 +34,4 @@ group :test do
   gem "database_cleaner"
   gem "webmock", require: false
   gem "mocha", require: false
-end
-
-group :production do
-  gem 'rails_12factor'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,7 +146,6 @@ GEM
     public_suffix (2.0.5)
     puma (3.8.2)
     rack (2.0.3)
-    rack-ssl-enforcer (0.2.9)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (5.0.3)
@@ -170,11 +169,6 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (5.0.3)
       actionpack (= 5.0.3)
       activesupport (= 5.0.3)
@@ -243,10 +237,8 @@ DEPENDENCIES
   possessive
   pry-byebug
   puma
-  rack-ssl-enforcer
   rails (= 5.0.3)
   rails-controller-testing
-  rails_12factor
   sass-rails (~> 5.0.6)
   uglifier (~> 3.2.0)
   webmock


### PR DESCRIPTION
Now that the app has been upgraded to use Rails 5, these gems are no 
longer needed and have been replaced by settings in `production.rb` 
instead.