### PR TITLE
Fix missing info on the book history page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
-  before_action :authenticate!
+  before_action :authenticate!, :set_paper_trail_whodunnit
 
 private
   include ApplicationHelper


### PR DESCRIPTION
The book history page has stopped showing who made changes to the book
when you try to view the revision history, and now always shows 'Unknown
user'. This is due to a change to the `paper_trail` gem, which is
responsible for recording this information.

[Paper-trail changelog details](https://github.com/airblade/paper_trail/blob/master/CHANGELOG.md#500-2016-05-02)