### PR TITLE
Fix failing tests

### DIFF
--- a/test/factories/shelf.rb
+++ b/test/factories/shelf.rb
@@ -1,3 +1,0 @@
-FactoryGirl.define do
-  factory :shelf
-end

--- a/test/integration/copy_actions_test.rb
+++ b/test/integration/copy_actions_test.rb
@@ -43,10 +43,6 @@ class CopyActionsTest < ActionDispatch::IntegrationTest
       end
 
       context "given a shelf exists" do
-        setup do
-          @shelf = FactoryGirl.create(:shelf, :name => "Third floor")
-        end
-
         should "allow shelf to be set" do
           visit "/copy/123"
           within ".shelf" do
@@ -69,8 +65,6 @@ class CopyActionsTest < ActionDispatch::IntegrationTest
     context "given a copy is on loan to the signed in user" do
       setup do
         @copy = FactoryGirl.create(:copy, :book_reference => "123")
-        @shelf1 = FactoryGirl.create(:shelf, :name => "Third floor")
-        @shelf2 = FactoryGirl.create(:shelf, :name => "Sixth floor")
         @copy.borrow(signed_in_user)
       end
 

--- a/test/models/loan_test.rb
+++ b/test/models/loan_test.rb
@@ -75,7 +75,7 @@ describe Loan do
     end
 
     should 'set the returning shelf when present' do
-      shelf = create(:shelf)
+      shelf = Shelf.first
       @loan.return(nil, shelf)
 
       @loan.reload


### PR DESCRIPTION
Two tests are failing with Capybara::Ambiguous match errors - Capybara
is finding more shelves in the shelf drop down menu when on the page to
return a book than expected. This is because we use FactoryGirl to create
shelves for the tests, but the test database already contains shelves - we
already have shelves in the test database from the shelf data migration.

Since the test database already contains shelves, this commit stops
creating more shelves with factories.