### PR TITLE
Prevent mixed content

### DIFF
--- a/app/helpers/books_helper.rb
+++ b/app/helpers/books_helper.rb
@@ -4,7 +4,7 @@ module BooksHelper
     zoom = cover_sizes[size]
 
     if book.google_id
-      image_tag "http://books.google.co.uk/books?id=#{book.google_id}&printsec=frontcover&img=1&zoom=#{zoom}&edge=none&source=gbs_api", :alt => "#{book.title} by #{book.author}", :title => "#{book.title} by #{book.author}"
+      image_tag "https://books.google.co.uk/books?id=#{book.google_id}&printsec=frontcover&img=1&zoom=#{zoom}&edge=none&source=gbs_api", :alt => "#{book.title} by #{book.author}", :title => "#{book.title} by #{book.author}"
     else
       content_tag :div, :class => "placeholder_book" do
         concat(book.title)
@@ -16,8 +16,8 @@ module BooksHelper
   def cover_urls(book, size = "S")
     response = { }
 
-    response[:google] = "http://books.google.co.uk/books?id=#{book[:google_id]}&printsec=frontcover&img=1&zoom=#{cover_sizes[size]}&edge=none&source=gbs_api" if book[:google_id]
-    response[:openlibrary] = "http://covers.openlibrary.org/b/olid/#{book[:openlibrary_id]}-M.jpg" if book[:openlibrary_id]
+    response[:google] = "https://books.google.co.uk/books?id=#{book[:google_id]}&printsec=frontcover&img=1&zoom=#{cover_sizes[size]}&edge=none&source=gbs_api" if book[:google_id]
+    response[:openlibrary] = "https://covers.openlibrary.org/b/olid/#{book[:openlibrary_id]}-M.jpg" if book[:openlibrary_id]
 
     response
   end

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -7,7 +7,7 @@ FactoryGirl.define do
     provider 'google'
     sequence(:provider_uid)
     sequence(:image_url) {|n|
-      "http://example.org/users/#{n}.jpg"
+      "https://example.org/users/#{n}.jpg"
     }
   end
 end

--- a/test/integration/book_actions_test.rb
+++ b/test/integration/book_actions_test.rb
@@ -16,7 +16,7 @@ class BookActionsTest < ActionDispatch::IntegrationTest
         visit "/books/#{@book.id}"
 
         within ".cover" do
-          assert page.has_selector?("img[src='http://books.google.co.uk/books?id=mock-google-id&printsec=frontcover&img=1&zoom=1&edge=none&source=gbs_api']")
+          assert page.has_selector?("img[src='https://books.google.co.uk/books?id=mock-google-id&printsec=frontcover&img=1&zoom=1&edge=none&source=gbs_api']")
         end
 
         within ".title" do

--- a/test/integration/copy_actions_test.rb
+++ b/test/integration/copy_actions_test.rb
@@ -85,7 +85,6 @@ class CopyActionsTest < ActionDispatch::IntegrationTest
         assert_equal "/copy/123", current_path
         assert page.has_content?("123")
         assert page.has_content?("Available to borrow")
-        save_and_open_page
         within ".shelf" do
           assert page.has_content?("Sixth floor")
         end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -9,7 +9,7 @@ describe User do
       info: {
         name: 'Stub User',
         email: 'stub.user@example.org',
-        image: 'http://example.org/image.jpg',
+        image: 'https://example.org/image.jpg',
       }
     }
   }
@@ -21,7 +21,7 @@ describe User do
     assert_equal 'stub.user@example.org', user.email
     assert_equal 'google', user.provider
     assert_equal '12345', user.provider_uid
-    assert_equal 'http://example.org/image.jpg', user.image_url
+    assert_equal 'https://example.org/image.jpg', user.image_url
   end
 
   it 'can be found from a matching email' do


### PR DESCRIPTION
We serve the site over HTTPS, but fetch the book information over HTTP,
resulting in mixed passive content. This is a slight security risk, and results
in warnings in the browser console. Since HTTPS versions exist for the
external sites, let's switch to using those.