### PR TITLE
Pin omniauth-google-oauth2 gem to use later version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'pg'
 gem 'googlebooks'
 gem 'openlibrary'
 
-gem 'omniauth-google-oauth2'
+gem 'omniauth-google-oauth2', '~> 0.6.0'
 
 gem "formtastic"
 gem "possessive"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,7 @@ GEM
     factory_girl_rails (4.1.0)
       factory_girl (~> 4.1.0)
       railties (>= 3.0.0)
-    faraday (0.11.0)
+    faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     formtastic (3.1.5)
       actionpack (>= 3.2.13)
@@ -76,7 +76,7 @@ GEM
       actionpack (>= 4.1, < 5.2)
       activesupport (>= 4.1, < 5.2)
     hashdiff (0.3.4)
-    hashie (3.5.5)
+    hashie (3.6.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     httparty (0.15.5)
@@ -87,7 +87,7 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.1.0)
-    jwt (1.5.6)
+    jwt (2.1.0)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.5)
@@ -104,30 +104,29 @@ GEM
       rails (>= 4.1)
     mocha (1.2.1)
       metaclass (~> 0.0.1)
-    multi_json (1.12.1)
+    multi_json (1.13.1)
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     netrc (0.11.0)
     nio4r (2.0.0)
     nokogiri (1.7.2)
       mini_portile2 (~> 2.1.0)
-    oauth2 (1.3.1)
-      faraday (>= 0.8, < 0.12)
-      jwt (~> 1.0)
+    oauth2 (1.4.1)
+      faraday (>= 0.8, < 0.16.0)
+      jwt (>= 1.0, < 3.0)
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    omniauth (1.6.1)
-      hashie (>= 3.4.6, < 3.6.0)
+    omniauth (1.9.0)
+      hashie (>= 3.4.6, < 3.7.0)
       rack (>= 1.6.2, < 3)
-    omniauth-google-oauth2 (0.4.1)
-      jwt (~> 1.5.2)
-      multi_json (~> 1.3)
+    omniauth-google-oauth2 (0.6.0)
+      jwt (>= 2.0)
       omniauth (>= 1.1.1)
-      omniauth-oauth2 (>= 1.3.1)
-    omniauth-oauth2 (1.4.0)
-      oauth2 (~> 1.0)
-      omniauth (~> 1.2)
+      omniauth-oauth2 (>= 1.5)
+    omniauth-oauth2 (1.6.0)
+      oauth2 (~> 1.1)
+      omniauth (~> 1.9)
     openlibrary (1.0.0)
       json
       rest-client
@@ -230,7 +229,7 @@ DEPENDENCIES
   jquery-rails
   minitest-spec-rails
   mocha
-  omniauth-google-oauth2
+  omniauth-google-oauth2 (~> 0.6.0)
   openlibrary
   paper_trail (~> 7.0.2)
   pg
@@ -247,4 +246,4 @@ RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.15.0
+   1.16.3


### PR DESCRIPTION
The `omniauth-google-oauth2` gem had no version in the Gemfile, so we were
using version `0.4.1`. This version relies on the Google+ API, which  will
stop working on 7/3/19, but will start to intermittently fail from 28/1/19.
We need to be using version `0.5.4` or higher of `omniauth-google-oauth2` to hit
the new Google OAuth endpoints.

I think we also need to change the API key to get this change to work - the current
one has the `Google+ API` permission enabled. 