### PR TITLE
Add a Rake task to update the floor numbers for WCB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ before_script:
   - cp config/database.travis.yml config/database.yml
   - psql -c 'create database books_test;' -U postgres
   - bundle exec rake db:migrate RAILS_ENV=test
+  - bundle exec rake update_shelf_numbers_for_wcb

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -73,8 +72,7 @@ ActiveRecord::Schema.define(version: 20170408104943) do
     t.text     "object"
     t.datetime "created_at"
     t.text     "object_changes"
+    t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree
   end
-
-  add_index "versions", ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree
 
 end

--- a/lib/tasks/update_shelf_numbers_for_wcb.rake
+++ b/lib/tasks/update_shelf_numbers_for_wcb.rake
@@ -1,0 +1,9 @@
+desc "Update shelf numbers"
+
+task :update_shelf_numbers_for_wcb => :environment do
+  puts "Updating #{Shelf.count} shelves..."
+  puts "Renamed 6th Floor to 7th Floor..."
+  Shelf.last.update_attributes(name: "7th floor")
+  puts "Renamed 3rd Floor to 6th Floor..."
+  Shelf.first.update_attributes(name: "6th floor")
+end

--- a/test/integration/copy_actions_test.rb
+++ b/test/integration/copy_actions_test.rb
@@ -51,12 +51,12 @@ class CopyActionsTest < ActionDispatch::IntegrationTest
 
           assert_equal "/copy/123/edit", current_path
 
-          select "Third floor", from: "Shelf"
+          select "6th floor", from: "Shelf"
           click_on "Set shelf"
 
           assert_equal "/copy/123", current_path
           within ".shelf" do
-            assert page.has_content?("Third floor")
+            assert page.has_content?("6th floor")
           end
         end
       end
@@ -79,14 +79,14 @@ class CopyActionsTest < ActionDispatch::IntegrationTest
 
       should "allow the book to be returned" do
         visit "/copy/123"
-        select "Sixth floor", from: "Return to"
+        select "7th floor", from: "Return to"
         click_on "Return"
 
         assert_equal "/copy/123", current_path
         assert page.has_content?("123")
         assert page.has_content?("Available to borrow")
         within ".shelf" do
-          assert page.has_content?("Sixth floor")
+          assert page.has_content?("7th floor")
         end
       end
     end


### PR DESCRIPTION
- In AH, GDS occupied the 3rd and 6th floors. Now, in WCB,
  we occupy the 6th and 7th floors.
- This changes 6th floor to 7th floor _before_ 3rd floor to 6th floor,
  otherwise we'd change _all_ of the floors to be 7th floor.
- As all books are on shelves referenced by their `shelf_id`, we don't
  have to do a mass data migration to remap 3rd books to 6th books etc.
  Existing books now show up (tested in dev) as on 6th or 7th floor.