### PR TITLE
Update stack and buildpack to cflinuxfs3

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,6 +2,7 @@
 applications:
 - name: gds-library
   memory: 256M
+  stack: cflinuxfs3
   buildpacks:
-    - https://github.com/cloudfoundry/ruby-buildpack/releases/download/v1.7.32/ruby-buildpack-cflinuxfs2-v1.7.32.zip
+    - https://github.com/cloudfoundry/ruby-buildpack/releases/download/v1.7.32/ruby-buildpack-cflinuxfs3-v1.7.32.zip
   instances: 2


### PR DESCRIPTION
Shortly cflinuxfs3 will be the default in GOV.UK PaaS, as a custom buildpack is in use this needs updating to reflect this change as it will not be automatically picked up.