### PR TITLE
Add a rake task to allow a book to be deleted

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
   - 2.6.1
-services: postgres
+services: postgresql
 before_script:
   - rm config/database.yml
   - cp config/database.travis.yml config/database.yml

--- a/lib/tasks/delete_book.rake
+++ b/lib/tasks/delete_book.rake
@@ -1,0 +1,12 @@
+desc "Permanently deletes a book (and all of its copies) from the library"
+
+task :delete_book, [:id] => :environment do |task, args|
+  book_id = args.id
+  unless book_id
+    puts "This task needs a book_id: rake delete_book[1] "
+    exit
+  end
+
+  Book.find(book_id).destroy
+  puts "Deleted book #{book_id}"
+end


### PR DESCRIPTION
Got asked to delete a few books recently and realised we currently have no way of deleting a book through the UI. This adds a rake task to delete a book, so that we have a consistent way of doing it and don't need to double check all the model relationships each time. (Probably not worth adding anything in the UI to delete books unless we start needing to do it more often.)